### PR TITLE
Enable screenshots to be overwritten by a new config key

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,8 @@ To install Tiny Scraper on your Anbernic device, follow these steps:
     "password": "your_password",
     "media_type": "sstitle",
     "region": "wor",
-    "resize": false
+    "resize": false,
+    "overwrite_screenshots": false
 }
 ```
 
@@ -44,6 +45,8 @@ To install Tiny Scraper on your Anbernic device, follow these steps:
 - Region let's you prioritize the region of the media to download. Some games have different covers for Japan, some for Europe and some for the rest of the world. If the region is not specified it will prioritize the world covers, also if the media type is not available on the preferred region, we will get the first one available. Valid regions are `wor`, `jp`, `eu`, `asi`, `kr`, `ss`, `us`.
 
 - Resize: `true` or `false` — Will resize the downloaded media to 320 by 240, saving space and avoiding slowdowns when listing the roms. But it might make scraping in bulk a bit slower.
+
+- Overwrite Screenshots: `true` or `false` — If set to `true`, existing screenshots will be overwritten by newly scraped ones. If set to `false`, existing screenshots will be preserved.
 
 3. **Start Tiny Scraper:**
    - From the main menu, go to App Center, select Apps and launch Tiny Scraper.

--- a/tiny_scraper/app.py
+++ b/tiny_scraper/app.py
@@ -280,14 +280,15 @@ def load_roms_menu() -> None:
     gr.draw_paint()
 
 def save_screenshot(img_path: Path, screenshot: bytes) -> None:
-    if scraper.resize:
-        print("Resizing image...")
-        img = Image.open(BytesIO(screenshot))
-        target_size = (320, 240)
-        img = img.resize(target_size, Image.LANCZOS)
-        img.save(img_path)
-    else:
-        img_path.write_bytes(screenshot)
+    if scraper.overwrite_screenshots or not img_path.exists():
+        if scraper.resize:
+            print("Resizing image...")
+            img = Image.open(BytesIO(screenshot))
+            target_size = (320, 240)
+            img = img.resize(target_size, Image.LANCZOS)
+            img.save(img_path)
+        else:
+            img_path.write_bytes(screenshot)
 
 def row_list(text: str, pos: tuple[int, int], width: int, selected: bool) -> None:
     gr.draw_rectangle_r(

--- a/tiny_scraper/scraper.py
+++ b/tiny_scraper/scraper.py
@@ -28,6 +28,7 @@ class Scraper:
         self.media_type = "ss"
         self.region = "wor"
         self.resize = False
+        self.overwrite_screenshots = False
 
     def load_config_from_json(self, filepath) -> bool:
         if not os.path.exists(filepath):
@@ -41,6 +42,7 @@ class Scraper:
             self.media_type = config.get("media_type") or "ss"
             self.region = config.get("region") or "wor"
             self.resize = config.get("resize") is True
+            self.overwrite_screenshots = config.get("overwrite_screenshots") is True
         return True
 
     def get_crc32_from_file(self, rom, chunk_size = 65536):


### PR DESCRIPTION
Add a new configuration key `overwrite_screenshots` to the `load_config_from_json` function in `tiny_scraper/scraper.py`.

Update the `save_screenshot` function in `tiny_scraper/app.py` to handle the `overwrite_screenshots` configuration key.

Update the `readme.md` to include documentation for the new `overwrite_screenshots` configuration key in the `config.json` example.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Julioevm/tiny-scraper/pull/22?shareId=bac7f32a-4e82-4fdb-94b4-72836669e804).