### PR TITLE
Fallback to world region when fetching screenshots

### DIFF
--- a/tiny_scraper/scraper.py
+++ b/tiny_scraper/scraper.py
@@ -8,6 +8,8 @@ from urllib.request import urlopen, Request
 import urllib.parse
 from systems import get_system_extension, systems
 
+DEFAULT_REGION = 'wor'
+
 
 class Rom:
     def __init__(self, name, filename, crc=""):
@@ -26,7 +28,7 @@ class Scraper:
         self.devid = "cmVhdmVu"
         self.devpassword = "MDZXZUY5bTBldWs="
         self.media_type = "ss"
-        self.region = "wor"
+        self.region = DEFAULT_REGION
         self.resize = False
 
     def load_config_from_json(self, filepath) -> bool:
@@ -112,17 +114,36 @@ class Scraper:
                         data = json.loads(response.read())
                         game_data = data.get("response").get("jeu")
 
+                        medias = [media for media in game_data.get("medias", [])
+                                  if media["type"] == self.media_type]
+                        
                         screenshot_url = ""
-                        for media in game_data.get("medias"):
-                            if media["type"] == self.media_type:
-                                if media["region"] == self.region:
+                        # Try to find a media matching the region
+                        for media in medias:
+                            if media.get("region") == self.region:
+                                print(f"Found screenshot found for media type '{self.media_type}' in region '{self.region}'")
+                                screenshot_url = media["url"]
+                                break
+                        
+                        if not screenshot_url:
+                            print(f"No matching screenshot found for media type '{self.media_type}' in region '{self.region}'. Trying default region ('{DEFAULT_REGION}')")
+                        # Fall back to DEFAULT_REGION if no match
+                        if not screenshot_url:
+                            for media in medias:
+                                if media.get("region") == DEFAULT_REGION:
                                     screenshot_url = media["url"]
+                                    print(f"Found screenshot in default region ('{DEFAULT_REGION})'")
                                     break
-                                elif (
-                                    not screenshot_url
-                                ):  # Keep the first one as fallback
-                                    print(f"No media found for this region {self.region} and type {self.media_type} combination for {game_name}")
-                                    screenshot_url = media["url"]
+
+                        if not screenshot_url:
+                            print(f"Still no match in default region. Trying any region...")
+
+                        # Fall back to first match
+                        if not screenshot_url:
+                            for media in medias:
+                                screenshot_url = media["url"]
+                                print(f"Found screenshot in region '{media.region}'")
+                                break
 
                         if screenshot_url:
                             img_request = Request(screenshot_url)

--- a/tiny_scraper/scraper.py
+++ b/tiny_scraper/scraper.py
@@ -115,15 +115,28 @@ class Scraper:
                         game_data = data.get("response").get("jeu")
 
                         medias = [media for media in game_data.get("medias", [])
-                                  if media["type"] == self.media_type]
+                                  if media.get("type") == self.media_type]
                         
                         screenshot_url = ""
-                        # Try to find a media matching the region
-                        for media in medias:
-                            if media.get("region") == self.region:
-                                print(f"Found screenshot found for media type '{self.media_type}' in region '{self.region}'")
-                                screenshot_url = media["url"]
+                        # Define priority: target region, then default region, then any
+                        regions_to_try = [self.region]
+                        if DEFAULT_REGION not in regions_to_try:
+                            regions_to_try.append(DEFAULT_REGION)
+
+                        for target in regions_to_try:
+                            for media in medias:
+                                if media.get("region") == target:
+                                    screenshot_url = media.get("url")
+                                    print(f"Found screenshot for media type '{self.media_type}' in region '{target}'")
+                                    break
+                            if screenshot_url:
                                 break
+                        
+                        # Fallback to first available if still no match
+                        if not screenshot_url and medias:
+                            screenshot_url = medias[0].get("url")
+                            print(f"No match for preferred regions. Using fallback region '{medias[0].get('region')}'")
+
                         
                         if not screenshot_url:
                             print(f"No matching screenshot found for media type '{self.media_type}' in region '{self.region}'. Trying default region ('{DEFAULT_REGION}')")


### PR DESCRIPTION
The current implementation fallback to the first screenshot it finds, which results in screenshots that are different languages and can be confusing. 
For instance, I set my `region` to `us`, but there's usually no `sstitle` media for the US. As a result, I would get some screenshots in Dutch, some in Japanese, etc.

**Tested on my RG35xx Plus**

## Before
selected region -> first region in API response

## After
selected region -> "world" region -> first region in API response

## Log output
```
Starting Tiny Scraper...
Scraping screenshot for Advance Wars 2 - Black Hole Rising...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Advance Wars 2 - Black Hole Rising. Saved file to /mnt/mmc/Roms/GBA/Imgs/Advance Wars 2 - Black Hole Rising.png
Scraping screenshot for Dragon Ball Z - Buu's Fury (USA)...
Found screenshot found for media type 'sstitle' in region 'us'
Done scraping Dragon Ball Z - Buu's Fury (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Dragon Ball Z - Buu's Fury (USA).png
Scraping screenshot for Dragon Ball Z - Supersonic Warriors (USA)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Dragon Ball Z - Supersonic Warriors (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Dragon Ball Z - Supersonic Warriors (USA).png
Scraping screenshot for Dragon Ball Z - The Legacy of Goku (USA)...
Found screenshot found for media type 'sstitle' in region 'us'
Done scraping Dragon Ball Z - The Legacy of Goku (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Dragon Ball Z - The Legacy of Goku (USA).png
Scraping screenshot for Dragon Ball Z - The Legacy of Goku II (USA)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Dragon Ball Z - The Legacy of Goku II (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Dragon Ball Z - The Legacy of Goku II (USA).png
Scraping screenshot for Final Fantasy IV Advance...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Final Fantasy IV Advance. Saved file to /mnt/mmc/Roms/GBA/Imgs/Final Fantasy IV Advance.png
Scraping screenshot for Final Fantasy Tactics Advance...
Found screenshot found for media type 'sstitle' in region 'us'
Done scraping Final Fantasy Tactics Advance. Saved file to /mnt/mmc/Roms/GBA/Imgs/Final Fantasy Tactics Advance.png
Scraping screenshot for Final Fantasy V Advance...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Final Fantasy V Advance. Saved file to /mnt/mmc/Roms/GBA/Imgs/Final Fantasy V Advance.png
Scraping screenshot for Final Fantasy VI Advance...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Final Fantasy VI Advance. Saved file to /mnt/mmc/Roms/GBA/Imgs/Final Fantasy VI Advance.png
Scraping screenshot for Golden Sun (USA, Europe)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Golden Sun (USA, Europe). Saved file to /mnt/mmc/Roms/GBA/Imgs/Golden Sun (USA, Europe).png
Scraping screenshot for Golden Sun - The Lost Age (USA, Europe)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Golden Sun - The Lost Age (USA, Europe). Saved file to /mnt/mmc/Roms/GBA/Imgs/Golden Sun - The Lost Age (USA, Europe).png
Scraping screenshot for Mario & Luigi - Superstar Saga (USA)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Mario & Luigi - Superstar Saga (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Mario & Luigi - Superstar Saga (USA).png
Scraping screenshot for Megaman - Battle Network 3 - Blue Version (USA)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Megaman - Battle Network 3 - Blue Version (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Megaman - Battle Network 3 - Blue Version (USA).png
Scraping screenshot for Megaman - Battle Network 4 - Red Sun (USA)...
Found screenshot found for media type 'sstitle' in region 'us'
Done scraping Megaman - Battle Network 4 - Red Sun (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Megaman - Battle Network 4 - Red Sun (USA).png
Scraping screenshot for Megaman - Battle Network 5 - Team Protoman (USA)...
Found screenshot found for media type 'sstitle' in region 'us'
Done scraping Megaman - Battle Network 5 - Team Protoman (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Megaman - Battle Network 5 - Team Protoman (USA).png
Scraping screenshot for Megaman - Battle Network 6 - Cybeast Gregar (USA)...
Found screenshot found for media type 'sstitle' in region 'us'
Done scraping Megaman - Battle Network 6 - Cybeast Gregar (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Megaman - Battle Network 6 - Cybeast Gregar (USA).png
Scraping screenshot for Megaman Zero 4 (USA)...
Found screenshot found for media type 'sstitle' in region 'us'
Done scraping Megaman Zero 4 (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Megaman Zero 4 (USA).png
Scraping screenshot for Metroid - Zero Mission...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Metroid - Zero Mission. Saved file to /mnt/mmc/Roms/GBA/Imgs/Metroid - Zero Mission.png
Scraping screenshot for Metroid Fusion...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Metroid Fusion. Saved file to /mnt/mmc/Roms/GBA/Imgs/Metroid Fusion.png
Scraping screenshot for Pokemon - Emerald Version...
Found screenshot found for media type 'sstitle' in region 'us'
Done scraping Pokemon - Emerald Version. Saved file to /mnt/mmc/Roms/GBA/Imgs/Pokemon - Emerald Version.png
Scraping screenshot for Pokemon - FireRed Version...
Found screenshot found for media type 'sstitle' in region 'us'
Done scraping Pokemon - FireRed Version. Saved file to /mnt/mmc/Roms/GBA/Imgs/Pokemon - FireRed Version.png
Scraping screenshot for Pokemon - Heart & Soul v1.2.1...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Pokemon - Heart & Soul v1.2.1. Saved file to /mnt/mmc/Roms/GBA/Imgs/Pokemon - Heart & Soul v1.2.1.png
Scraping screenshot for Pokemon - Light Platinum v1.0...
Error scraping screenshot for Pokemon - Light Platinum v1.0: HTTP Error 404: Not Found
URL used: https://api.screenscraper.fr/api2/jeuInfos.php?devid=****&devpassword=***&softname=tiny-scraper&output=json&ssid=***&sspassword=***&crc=***&systemeid=***&romtype=rom&romnom=Pokemon%20-%20Light%20Platinum%20v1.0
Failed to get screenshot for Pokemon - Light Platinum v1.0
Scraping screenshot for Pokemon - Radical Red v4.1...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Pokemon - Radical Red v4.1. Saved file to /mnt/mmc/Roms/GBA/Imgs/Pokemon - Radical Red v4.1.png
Scraping screenshot for Pokemon - Ruby Version...
Found screenshot found for media type 'sstitle' in region 'us'
Done scraping Pokemon - Ruby Version. Saved file to /mnt/mmc/Roms/GBA/Imgs/Pokemon - Ruby Version.png
Scraping screenshot for Pokemon Elite Redux v2.5-hotfix2...
Error scraping screenshot for Pokemon Elite Redux v2.5-hotfix2: HTTP Error 404: Not Found
URL used: https://api.screenscraper.fr/api2/jeuInfos.php?devid=***&devpassword=***&softname=tiny-scraper&output=json&ssid=***&sspassword=***&crc=***&systemeid=***&romtype=rom&romnom=Pokemon%20Elite%20Redux%20v2.5-hotfix2
Failed to get screenshot for Pokemon Elite Redux v2.5-hotfix2
Scraping screenshot for Pokemon FireRed Rocket Edition v1.02...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Pokemon FireRed Rocket Edition v1.02. Saved file to /mnt/mmc/Roms/GBA/Imgs/Pokemon FireRed Rocket Edition v1.02.png
Scraping screenshot for Pokemon Mystery Dungeon - Red Rescue Team...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Pokemon Mystery Dungeon - Red Rescue Team. Saved file to /mnt/mmc/Roms/GBA/Imgs/Pokemon Mystery Dungeon - Red Rescue Team.png
Scraping screenshot for Super Mario Advance...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Super Mario Advance. Saved file to /mnt/mmc/Roms/GBA/Imgs/Super Mario Advance.png
Scraping screenshot for Super Mario Advance 2 - Super Mario World...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Super Mario Advance 2 - Super Mario World. Saved file to /mnt/mmc/Roms/GBA/Imgs/Super Mario Advance 2 - Super Mario World.png
Scraping screenshot for Super Mario Advance 3 - Yoshi's Island...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Super Mario Advance 3 - Yoshi's Island. Saved file to /mnt/mmc/Roms/GBA/Imgs/Super Mario Advance 3 - Yoshi's Island.png
Scraping screenshot for Super Mario Advance 4 - Super Mario Bros. 3...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Super Mario Advance 4 - Super Mario Bros. 3. Saved file to /mnt/mmc/Roms/GBA/Imgs/Super Mario Advance 4 - Super Mario Bros. 3.png
Scraping screenshot for Sword of Mana...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Sword of Mana. Saved file to /mnt/mmc/Roms/GBA/Imgs/Sword of Mana.png
Scraping screenshot for Yu-Gi-Oh! - Destiny Board Traveler (USA)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Yu-Gi-Oh! - Destiny Board Traveler (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Yu-Gi-Oh! - Destiny Board Traveler (USA).png
Scraping screenshot for Yu-Gi-Oh! - The Eternal Duelist Soul (USA)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Yu-Gi-Oh! - The Eternal Duelist Soul (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Yu-Gi-Oh! - The Eternal Duelist Soul (USA).png
Scraping screenshot for Yu-Gi-Oh! - The Sacred Cards (USA)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Yu-Gi-Oh! - The Sacred Cards (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Yu-Gi-Oh! - The Sacred Cards (USA).png
Scraping screenshot for Yu-Gi-Oh! - Ultimate Masters - World Championship Tournament 2006 (USA)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Yu-Gi-Oh! - Ultimate Masters - World Championship Tournament 2006 (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Yu-Gi-Oh! - Ultimate Masters - World Championship Tournament 2006 (USA).png
Scraping screenshot for Yu-Gi-Oh! - Worldwide Edition - Stairway to the Destined Duel (USA)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Yu-Gi-Oh! - Worldwide Edition - Stairway to the Destined Duel (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Yu-Gi-Oh! - Worldwide Edition - Stairway to the Destined Duel (USA).png
Scraping screenshot for Yu-Gi-Oh! GX - Duel Academy (USA)...
No matching screenshot found for media type 'sstitle' in region 'us'. Trying default region ('wor')
Found screenshot in default region ('wor)'
Done scraping Yu-Gi-Oh! GX - Duel Academy (USA). Saved file to /mnt/mmc/Roms/GBA/Imgs/Yu-Gi-Oh! GX - Duel Academy (USA).png
Exiting Tiny Scraper...
```